### PR TITLE
feat(add-jira-custom-lookup): Add lookup for Jira custom fields

### DIFF
--- a/src/libs/error-lib.ts
+++ b/src/libs/error-lib.ts
@@ -1,5 +1,0 @@
-export class Logger {
-  static logError(error: Error) {
-    console.error(`Error: ${error.name}: ${error.message}`);
-  }
-}

--- a/src/libs/index.ts
+++ b/src/libs/index.ts
@@ -1,3 +1,2 @@
-export * from "./error-lib";
 export * from "./jira-lib";
 export * from "./security-hub-lib";

--- a/src/libs/jira-lib.ts
+++ b/src/libs/jira-lib.ts
@@ -5,6 +5,7 @@ dotenv.config();
 
 export class Jira {
   private readonly jira;
+  private jiraFields: JiraClient.FieldObject[] | undefined;
   jiraClosedStatuses: string[];
 
   constructor() {
@@ -84,6 +85,15 @@ export class Jira {
 
       issue.fields.project = { key: process.env.JIRA_PROJECT };
 
+      if (issue.fields.customJiraFields) {
+        issue.fields = {
+          ...issue.fields,
+          ...(await this.mapCustomFieldNamesToIds(
+            issue.fields.customJiraFields
+          )),
+        };
+        delete issue.fields.customJiraFields;
+      }
       const response = await this.jira.addNewIssue(issue);
       response[
         "webUrl"
@@ -118,5 +128,32 @@ export class Jira {
         `Failed to transition issue ${issueKey} to "Done": ${error}`
       );
     }
+  }
+
+  async mapCustomFieldNamesToIds(customJiraFields: {
+    [fieldName: string]: string;
+  }) {
+    if (!this.jiraFields) {
+      try {
+        this.jiraFields = await this.jira.listFields();
+      } catch (error) {
+        throw new Error("Failed to retrieve Jira Fields");
+      }
+    }
+    const mappedFields = Object.entries(customJiraFields).reduce(
+      (acc: { [key: string]: [{ value: string }] }, [fieldName, value]) => {
+        const customField = this.jiraFields!.find(
+          (field) => field.name === fieldName
+        );
+        if (!customField) {
+          throw new Error(`Cannot find custom field named "${fieldName}"`);
+        }
+        acc[customField.id] = [{ value }];
+        return acc;
+      },
+      {}
+    );
+
+    return mappedFields;
   }
 }

--- a/src/libs/security-hub-lib.ts
+++ b/src/libs/security-hub-lib.ts
@@ -6,7 +6,6 @@ import {
   Remediation,
   AwsSecurityFinding,
 } from "@aws-sdk/client-securityhub";
-import { Logger } from "./error-lib";
 
 export interface SecurityHubFinding {
   title?: string;
@@ -33,7 +32,7 @@ export class SecurityHub {
       Comparison: "EQUALS",
       Value: severity,
     }));
-    this.getAccountAlias().catch((error) => Logger.logError(error));
+    this.getAccountAlias().catch((error) => console.log(error));
   }
 
   private async getAccountAlias(): Promise<void> {
@@ -83,7 +82,7 @@ export class SecurityHub {
         return { accountAlias: this.accountAlias, ...finding };
       });
     } catch (error) {
-      Logger.logError(error as Error);
+      console.log(error);
       return [];
     }
   }

--- a/src/macpro-security-hub-sync.ts
+++ b/src/macpro-security-hub-sync.ts
@@ -172,7 +172,7 @@ export class SecurityHubJiraSync {
           finding.accountAlias,
           ...identifyingLabels,
         ],
-        ...this.customJiraFields,
+        customJiraFields: this.customJiraFields,
       },
     };
     const newIssueInfo = await this.jira.createNewIssue(newIssueData);

--- a/src/run-sync.ts
+++ b/src/run-sync.ts
@@ -3,4 +3,8 @@ import { SecurityHubJiraSync } from "./macpro-security-hub-sync";
 new SecurityHubJiraSync({
   region: "us-east-1",
   severities: ["CRITICAL", "HIGH"],
+  customJiraFields: {
+    "Working Team": "Dev Team",
+    "Product Supported": "OneMac",
+  },
 }).sync();


### PR DESCRIPTION
## Purpose

Added functionality to lookup Jira custom fields and no longer require the custom IDs.

#### Linked Issues to Close

[None](https://github.com/Enterprise-CMCS/macpro-security-hub-sync/issues/10)

## Design / Approach / Notes

Adds functionality to lookup the custom fields by name.