### PR TITLE
feat(standardize errors): Standardize error handling

### DIFF
--- a/src/libs/security-hub-lib.ts
+++ b/src/libs/security-hub-lib.ts
@@ -81,9 +81,8 @@ export class SecurityHub {
       return Array.from(uniqueFindings).map((finding) => {
         return { accountAlias: this.accountAlias, ...finding };
       });
-    } catch (error) {
-      console.error(error);
-      return [];
+    } catch (e: any) {
+      throw new Error(`Error getting Security Hub findings: ${e.message}`);
     }
   }
 


### PR DESCRIPTION
## Purpose

I noticed that the Security Hub library returned an empty list when it encountered an error fetching findings from AWS.  This led to all open Jira issues getting closed since the tool thought they were no longer backed by a finding, which I think is not the desired behavior in this case.  Better to simply return the error to the user.

#### Linked Issues to Close

## Design / Approach / Notes

This change standardizes error handling by catching the error and throwing a new `Error` with a descriptive message that identifies the action that generated the error, followed by the actual error message.  E.g. `Error getting Security Hub findings: <actual AWS error message here>`

Manual testing:  I triggered as many errors as I could by tinkering with Jira and AWS creds