### PR TITLE
Fix DELETE request made to remove watchers from Jira issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,20 @@ success Using linked package for "@enterprise-cmcs/macpro-security-hub-sync".
 - `yarn install`
 - Note: when testing is complete run `yarn unlink "@enterprise-cmcs/macpro-security-hub-sync"`
 
+#### Instructions to test locally in an npm project
+In your terminal, in the root directory of your local clone of this repo, with your development branch checked out run `npm link`.
+
+Then, in your project that will be consuming this package, remove your `node_modules` folder and run `npm link "@enterprise-cmcs/macpro-security-hub-sync"`, and then rebuild your project:
+
+```bash
+$ rm -rf node_modules
+$ npm link "@enterprise-cmcs/macpro-security-hub-sync" --save
+$ npm install
+$ npm run build
+```
+
+When you're finished, be sure to run `npm unlink "@enterprise-cmcs/macpro-security-hub-sync"` in your project that is consuming this pacakage. And then run `npm unlink -g` in the root directory of this repo.
+
 ## Contributing
 
 Work items for this project are tracked in Jira. Check out the [project kanban board](https://qmacbis.atlassian.net/jira/software/c/projects/OY2/boards/251) to view all work items affecting this repo.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ success Using linked package for "@enterprise-cmcs/macpro-security-hub-sync".
 - Note: when testing is complete run `yarn unlink "@enterprise-cmcs/macpro-security-hub-sync"`
 
 #### Instructions to test locally in an npm project
+
 In your terminal, in the root directory of your local clone of this repo, with your development branch checked out run `npm link`.
 
 Then, in your project that will be consuming this package, remove your `node_modules` folder, run `npm link "@enterprise-cmcs/macpro-security-hub-sync --save"`, and then rebuild your project:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ success Using linked package for "@enterprise-cmcs/macpro-security-hub-sync".
 #### Instructions to test locally in an npm project
 In your terminal, in the root directory of your local clone of this repo, with your development branch checked out run `npm link`.
 
-Then, in your project that will be consuming this package, remove your `node_modules` folder and run `npm link "@enterprise-cmcs/macpro-security-hub-sync"`, and then rebuild your project:
+Then, in your project that will be consuming this package, remove your `node_modules` folder, run `npm link "@enterprise-cmcs/macpro-security-hub-sync --save"`, and then rebuild your project:
 
 ```bash
 $ rm -rf node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@enterprise-cmcs/macpro-security-hub-sync",
+  "name": "security-hub-sync-jira-enterprise",
   "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@enterprise-cmcs/macpro-security-hub-sync",
+      "name": "security-hub-sync-jira-enterprise",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +13,7 @@
         "@aws-sdk/client-securityhub": "^3.317.0",
         "@aws-sdk/client-sts": "^3.316.0",
         "@types/jira-client": "^7.1.6",
-        "axios": "^1.6.2",
+        "axios": "^1.3.6",
         "dotenv": "^16.0.3",
         "jira-client": "^8.2.2"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "security-hub-sync-jira-enterprise",
+  "name": "@enterprise-cmcs/macpro-security-hub-sync",
   "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "security-hub-sync-jira-enterprise",
+      "name": "@enterprise-cmcs/macpro-security-hub-sync",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
@@ -13,7 +13,7 @@
         "@aws-sdk/client-securityhub": "^3.317.0",
         "@aws-sdk/client-sts": "^3.316.0",
         "@types/jira-client": "^7.1.6",
-        "axios": "^1.3.6",
+        "axios": "^1.6.2",
         "dotenv": "^16.0.3",
         "jira-client": "^8.2.2"
       },

--- a/src/libs/jira-lib.ts
+++ b/src/libs/jira-lib.ts
@@ -64,6 +64,7 @@ export class Jira {
   async removeCurrentUserAsWatcher(issueKey: string) {
     try {
       const currentUser = await this.jira.getCurrentUser();
+      console.log("removing current user: ", currentUser);
 
       // Remove the current user as a watcher
       const axiosHeader = {

--- a/src/libs/jira-lib.ts
+++ b/src/libs/jira-lib.ts
@@ -64,7 +64,6 @@ export class Jira {
   async removeCurrentUserAsWatcher(issueKey: string) {
     try {
       const currentUser = await this.jira.getCurrentUser();
-      console.log("removing current user: ", currentUser);
 
       // Remove the current user as a watcher
       const axiosHeader = {

--- a/src/libs/jira-lib.ts
+++ b/src/libs/jira-lib.ts
@@ -4,10 +4,10 @@ import JiraClient, {
   TransitionObject,
 } from "jira-client";
 import * as dotenv from "dotenv";
-import axios, { 
-  AxiosHeaderValue, 
-  AxiosHeaders, 
-  AxiosRequestConfig, 
+import axios, {
+  AxiosHeaderValue,
+  AxiosHeaders,
+  AxiosRequestConfig,
 } from "axios";
 
 dotenv.config();

--- a/src/libs/jira-lib.ts
+++ b/src/libs/jira-lib.ts
@@ -78,11 +78,11 @@ export class Jira {
       }
       await axios({
         method: "DELETE",
-        url: `https://${process.env.JIRA_HOST}/rest/api/3/issue/${issueKey}/watchers`,
+        url: `https://${process.env.JIRA_HOST}/rest/api/2/issue/${issueKey}/watchers?username=${currentUser.name}`,
         headers: axiosHeader,
-        params: {
-          accountId: currentUser.accountId,
-        },
+        // params: {
+        //   accountId: currentUser.accountId,
+        // },
       });
     } catch (err) {
       console.error("Error creating issue or removing watcher:", err);

--- a/src/libs/jira-lib.ts
+++ b/src/libs/jira-lib.ts
@@ -80,9 +80,6 @@ export class Jira {
         method: "DELETE",
         url: `https://${process.env.JIRA_HOST}/rest/api/2/issue/${issueKey}/watchers?username=${currentUser.name}`,
         headers: axiosHeader,
-        // params: {
-        //   accountId: currentUser.accountId,
-        // },
       });
     } catch (err) {
       console.error("Error creating issue or removing watcher:", err);

--- a/src/libs/jira-lib.ts
+++ b/src/libs/jira-lib.ts
@@ -4,7 +4,11 @@ import JiraClient, {
   TransitionObject,
 } from "jira-client";
 import * as dotenv from "dotenv";
-import axios, { AxiosHeaderValue, AxiosHeaders } from "axios";
+import axios, { 
+  AxiosHeaderValue, 
+  AxiosHeaders, 
+  AxiosRequestConfig, 
+} from "axios";
 
 dotenv.config();
 
@@ -69,17 +73,29 @@ export class Jira {
       const axiosHeader = {
         Authorization: "",
       };
+
+      let url;
+      let reqParams;
+
+      // check version of jira
       if (process.env.JIRA_HOST?.includes("jiraent")) {
+        // if jira enterprise, use v2 of api and bearer token
         axiosHeader["Authorization"] = `Bearer ${process.env.JIRA_TOKEN}`;
+        url = `https://${process.env.JIRA_HOST}/rest/api/2/issue/${issueKey}/watchers?username=${currentUser.name}`;
       } else {
+        // otherwise use v3 and basic auth
         axiosHeader["Authorization"] = `Basic ${Buffer.from(
           `${process.env.JIRA_USERNAME}:${process.env.JIRA_TOKEN}`
         ).toString("base64")}`;
+        url = `https://${process.env.JIRA_HOST}/rest/api/3/issue/${issueKey}/watchers`;
+        reqParams = { accountId: currentUser.accountId };
       }
+
       await axios({
         method: "DELETE",
-        url: `https://${process.env.JIRA_HOST}/rest/api/2/issue/${issueKey}/watchers?username=${currentUser.name}`,
         headers: axiosHeader,
+        url: url,
+        params: reqParams,
       });
     } catch (err) {
       console.error("Error creating issue or removing watcher:", err);


### PR DESCRIPTION
## Purpose

_Describe the problem or feature in addition to a link to the issues._
https://jiraent.cms.gov/browse/CMCSMACD-2047

This PR fixes the [DELETE request](https://github.com/Enterprise-CMCS/macpro-security-hub-sync/blob/dd19ba282c2de2ffae234c9449e66de73769262f/src/libs/jira-lib.ts#L79) made to the `rest/api/3/<issueKey>/watchers` endpoint of the Jira API. The current request uses the v3 version of the API endpoint, which should only be used if this package is being used with Jira Cloud. The [v2 version](https://docs.atlassian.com/software/jira/docs/api/REST/9.13.0/#api/2/issue-removeWatcher) of the endpoint should be used if this package is being used with Enterprise Jira.

The `README` was also updated to include steps for testing locally using `npm link`, which allows npm projects consuming this package to test out the current changes before they are published. 

#### Linked Issues to Close

_Links to issue(s) that are closed by this PR. Be sure to use the phrase "Closes #XXX" for each issue, so they automatically close_
Closes https://jiraent.cms.gov/browse/CMCSMACD-2047

## Design / Approach / Notes

_How does this change address the issue?_
The DELETE request mades to remove the current user as a watcher on each Jira issue created from the Security Hub findings has been updated to use the v2 version of the api endpoint when this package is being used with Jira Enterprise. This version can successfully remove watchers from Enterprise Jira tickets with only the current user's `username`.
