### PR TITLE
fix(summary): limited the jira issue summary not to exceed 255 characters in length

### DIFF
--- a/src/macpro-security-hub-sync.ts
+++ b/src/macpro-security-hub-sync.ts
@@ -305,7 +305,7 @@ export class SecurityHubJiraSync {
     console.log(priorities);
     const newIssueData: IssueObject = {
       fields: {
-        summary: `SecurityHub Finding - ${finding.title}`,
+        summary: `SecurityHub Finding - ${finding.title}`.substring(0, 255),
         description: this.createIssueBody(finding),
         issuetype: { name: "Task" },
         labels: [


### PR DESCRIPTION
## Purpose

This PR limits the length of summary for jira issues created by security hub not to exceed 255 characters
