### PR TITLE
feat(label-config): added ability to specify label config

### DIFF
--- a/src/libs/security-hub-lib.ts
+++ b/src/libs/security-hub-lib.ts
@@ -25,6 +25,7 @@ export interface SecurityHubFinding {
   remediation?: Remediation;
   ProductName?: string;
   Resources?: Resource[];
+  [key: string]: string | unknown;
 }
 
 export class SecurityHub {


### PR DESCRIPTION
## Purpose

This PR adds ability to specify label config where user can select any prefix for the specific label
e.g.
 for config: "[{\"labelField\":\"ProductName\",\"labelPrefix\":\"product\",\"labelDelimiter\":\":\"},{\"labelField\":\"severity\"},{\"labelField\":\"accountId\",\"labelDelimiter\":\"-\",\"labelPrefix\":\"account\"},{\"labelField\":\"region\"}]"
labels will be: [ 'product:Health', 'MEDIUM', 'account-zxxxzxzxxxxxx', 'us-east-1' ]