### PR TITLE
Update security-hub-lib.ts. Add dynamic GeneratorId filtering

### DIFF
--- a/src/libs/security-hub-lib.ts
+++ b/src/libs/security-hub-lib.ts
@@ -94,6 +94,15 @@ export class SecurityHub {
           });
         });
       }
+      if (process.env.GENERATOR_ID) {
+        filters.GeneratorId = [
+          {
+            Value: process.env.GENERATOR_ID, // Use the environment variable
+            Comparison: "EQUALS"
+          }
+        ];
+      }
+
       // use an object to store unique findings by title
       const uniqueFindings: { [title: string]: SecurityHubFinding } = {};
 


### PR DESCRIPTION
 **Add dynamic GeneratorId filtering based on environment variable**  

- Fixed syntax error in `filters.GeneratorId` assignment  
- Updated logic to use `process.env.GENERATOR_ID` dynamically instead of hardcoding `"CheckOv"`  
- Ensured `filters.GeneratorId` is only assigned if `GENERATOR_ID` is defined

## Purpose

_Describe the problem or feature in addition to a link to the issues._

#### Linked Issues to Close

_Links to issue(s) that are closed by this PR. Be sure to use the phrase "Closes #XXX" for each issue, so they automatically close_

## Design / Approach / Notes

_How does this change address the issue?_
